### PR TITLE
human ecog tutorial

### DIFF
--- a/tutorial/human_ecog.md
+++ b/tutorial/human_ecog.md
@@ -16,7 +16,7 @@ Before we start, it is important to emphasize that human iEEG datasets are solel
 The tutorial demonstrates the analysis of task-related high-frequency-band activity (~70 to 150 Hz), a prominent neural signature in intracranial data that has been associated with neuron population level firing rate. Many other supported analyses such as event-related potential analysis, connectivity analysis, and statistical analysis have been described in detail elsewhere (Oostenveld et al., 2011; Maris & Oostenveld, 2007; Bastos & Schoffelen, 2016). You will need the iEEG data of SubjectUCI29, which can be obtained from [here](https://doi.org/10.5281/zenodo.1201560). If you are getting started with FieldTrip, download the most recent version from its homepage or GitHub and [set up your MATLAB path](/faq/should_i_add_fieldtrip_with_all_subdirectories_to_my_matlab_path).
 
 {% include markup/warning %}
-The information on this page originates from the human intracranial data analysis protocol described in Stolk, Griffin et al., **[Integrated analysis of anatomical and electrophysiological human intracranial data](https://www.nature.com/articles/s41596-018-0009-6)”**, Nature Protocols, 2018. Please cite that paper when you use the methods described here.
+The information on this page originates from the human intracranial data analysis protocol described in Stolk, Griffin et al., **[Integrated analysis of anatomical and electrophysiological human intracranial data](https://www.nature.com/articles/s41596-018-0009-6)**, Nature Protocols, 2018. Please cite that paper when you use the methods described here.
 {% include markup/end %}
 
 ## Background


### PR DESCRIPTION
removed an obsolete quotation mark

not sure if this can be merged with the other PR I just did since this PR doesn't have the changes made in that PR? if not, please remove that quotation mark manually after pulling in the previous PR first