### PR TITLE
fix broken link in tutorial/continuous

### DIFF
--- a/tutorial/continuous.md
+++ b/tutorial/continuous.md
@@ -249,7 +249,7 @@ The following example shows how to first read the data as a single continuous se
 
 ## Suggested further reading
 
-After having finished this tutorial on preprocessing, you can continue with the tutorial on [Preprocessing of EEG data and compute ERPs](/tutorial/preprocessing_ERP), with the [event related averaging](/tutorial/eventrelatedaveraging) or with the [time-frequency analysis](/tutorial/timefrequencyanalysis) tutorial.
+After having finished this tutorial on preprocessing, you can continue with the tutorial on [Preprocessing of EEG data and compute ERPs](/tutorial/preprocessing_erp), with the [event related averaging](/tutorial/eventrelatedaveraging) or with the [time-frequency analysis](/tutorial/timefrequencyanalysis) tutorial.
 
 If you have more questions about preprocessing, you can also read the following FAQs:
 


### PR DESCRIPTION
It seems the link has changed to lowercase erp.