### PR TITLE
Cull dead links on "how to share data" FAQ

### DIFF
--- a/faq/how_should_i_send_example_data_to_the_developers.md
+++ b/faq/how_should_i_send_example_data_to_the_developers.md
@@ -5,7 +5,7 @@ tags: [faq, email, development, bugzilla]
 
 # How should I share example data with the email list or developers?
 
-In general it is not a good idea to send data as email attachment to the email discussion list. You should consider that your data file will end up in ~1000 email inboxes of all other people that are subscribed. I.e. your 10 MB attachment would result in 10 GB of storage requirements. Also when sending example data to one of the developers, you should not send large data files as email attachment.
+In general it is not a good idea to send data as email attachment to the email discussion list. You should consider that your data file will end up in ~1000 email inboxes of all other people that are subscribed. I.e. your 10 MB attachment would result in 10 GB of storage requirements. Also when sending example data to one of the developers, you should not send large data files as email attachments.
 
 If the data that you want to send is too large for an email attachment, you can use one of the file sharing methods below:
 

--- a/faq/how_should_i_send_example_data_to_the_developers.md
+++ b/faq/how_should_i_send_example_data_to_the_developers.md
@@ -14,6 +14,4 @@ If the data that you want to send is too large for an email attachment, you can 
 - <https://www.hightail.com/>
 - <https://www.sendspace.com>
 
-or one of the other file sharing methods that is described [here](http://www.techlore.com/blog/entry/18653/Great-Ways-to-Send--Receive-or-Share-Large-Files).
-
 So instead of sending the large file as attachment, you would just include the download link in your email.

--- a/faq/how_should_i_send_example_data_to_the_developers.md
+++ b/faq/how_should_i_send_example_data_to_the_developers.md
@@ -11,7 +11,7 @@ If the data that you want to send is too large for an email attachment, you can 
 
 - <https://wetransfer.com>
 - <https://www.dropbox.com>
-- <http://www.yousendit.com>
+- <https://www.hightail.com/>
 - <https://www.sendspace.com>
 
 or one of the other file sharing methods that is described [here](http://www.techlore.com/blog/entry/18653/Great-Ways-to-Send--Receive-or-Share-Large-Files).

--- a/faq/how_should_i_send_example_data_to_the_developers.md
+++ b/faq/how_should_i_send_example_data_to_the_developers.md
@@ -10,9 +10,9 @@ In general it is not a good idea to send data as email attachment to the email d
 If the data that you want to send is too large for an email attachment, you can use one of the file sharing methods below:
 
 - <https://wetransfer.com>
-- <http://www.dropbox.com>
+- <https://www.dropbox.com>
 - <http://www.yousendit.com>
-- <http://www.sendspace.com>
+- <https://www.sendspace.com>
 
 or one of the other file sharing methods that is described [here](http://www.techlore.com/blog/entry/18653/Great-Ways-to-Send--Receive-or-Share-Large-Files).
 


### PR DESCRIPTION
This PR updates or removes dead or non-http links on the "how to share experimental data" page. In particular, it removes the whole paragraph referencing a now-gone external "best ways to share large files" page.