### PR TITLE
Example data FAQ: add Git LFS as a sharing technique

### DIFF
--- a/faq/how_should_i_send_example_data_to_the_developers.md
+++ b/faq/how_should_i_send_example_data_to_the_developers.md
@@ -18,21 +18,21 @@ or one of the other file sharing methods that is described [here](http://www.tec
 
 So instead of sending the large file as attachment, you would just include the download link in your email.
 
-## Using GitHub and Git LFS
+## Using GitHub and Git Large File Storage
 
 You can also share example data by storing it in a GitHub hosted repo using [Git LFS](https://git-lfs.github.com/). In addition to sharing a snapshot of a file's state, this also lets you track changes to the files over time, control access to the shared data, easily sync it between multiple machines, and collaborate by allowing multiple users to write changes to the file set.
 
-{% include markup/info %}
-Important: If this is confidential data, remember that by default, GitHub repos are public and visible to everyone. To keep your data private, you must make it a private repo, and selectively grant access to the users you wish to see it!
+{% include markup/danger %}
+If this is confidential data, remember that by default, GitHub repos are public and visible to everyone. To keep your data private, you must make it a private repo, and selectively grant access to the users you wish to see it.
 {% include markup/end %}
 
 To share files via Git LFS on GitHub:
 
-* Install [Git LFS](https://git-lfs.github.com/) on your local machine
-* On GitHub, [Create a new repository](https://github.com/new)
-  * Name it `example-<description>-yyyy-mm` or something similar; this is just example data so you do not need a memorable name
-* Clone the repo to your local machine
-* Run `git lfs install` inside the cloned local repo
-* Copy your example data files into the local repo
-* Use `git lfs track` to make sure the files you have added are tracked by Git LFS instead of committed as regular files
-* `git add` the files, `git commit`, and `git push`
+- Install [Git LFS](https://git-lfs.github.com/) on your computer
+- On GitHub, [Create a new repository](https://github.com/new)
+  - Name it `example-<description>-yyyy-mm` or something similar; this is just example data so you do not need a memorable name
+- Clone the repo to your local machine
+- Run `git lfs install` inside the cloned local repo
+- Copy your example data files into the local repo
+- Use `git lfs track` to make sure the files you have added are tracked by Git LFS instead of committed as regular files
+- `git add` the files, `git commit`, and `git push`

--- a/faq/how_should_i_send_example_data_to_the_developers.md
+++ b/faq/how_should_i_send_example_data_to_the_developers.md
@@ -17,3 +17,22 @@ If the data that you want to send is too large for an email attachment, you can 
 or one of the other file sharing methods that is described [here](http://www.techlore.com/blog/entry/18653/Great-Ways-to-Send--Receive-or-Share-Large-Files).
 
 So instead of sending the large file as attachment, you would just include the download link in your email.
+
+## Using GitHub and Git LFS
+
+You can also share example data by storing it in a GitHub hosted repo using [Git LFS](https://git-lfs.github.com/). In addition to sharing a snapshot of a file's state, this also lets you track changes to the files over time, control access to the shared data, easily sync it between multiple machines, and collaborate by allowing multiple users to write changes to the file set.
+
+{% include markup/info %}
+Important: If this is confidential data, remember that by default, GitHub repos are public and visible to everyone. To keep your data private, you must make it a private repo, and selectively grant access to the users you wish to see it!
+{% include markup/end %}
+
+To share files via Git LFS on GitHub:
+
+* Install [Git LFS](https://git-lfs.github.com/) on your local machine
+* On GitHub, [Create a new repository](https://github.com/new)
+  * Name it `example-<description>-yyyy-mm` or something similar; this is just example data so you do not need a memorable name
+* Clone the repo to your local machine
+* Run `git lfs install` inside the cloned local repo
+* Copy your example data files into the local repo
+* Use `git lfs track` to make sure the files you have added are tracked by Git LFS instead of committed as regular files
+* `git add` the files, `git commit`, and `git push`


### PR DESCRIPTION
Now that [GitHub lets free accounts have private repos](https://github.blog/2019-01-07-new-year-new-github/), Git LFS is a good way of sharing large example data sets between developers. It's especially useful because it can track file changes over time, and both the sender and receiver can check in changes, so it's good for iteratively working out bugs.

How about adding a section in the "How to send example data" FAQ for Git LFS & GitHub?