### PR TITLE
added Memory efficient coding tip

### DIFF
--- a/tutorial/memory.md
+++ b/tutorial/memory.md
@@ -17,12 +17,12 @@ Neurophysiological data can become quite large with the result that disk space, 
 
 - Work on your programming _style_. Take a look [here](http://www.datatool.com/downloads/matlab_style_guidelines.pdf) for a concise summary of the recommended style of programming.
 - Downsample your data (but backup your original data), e.g. using **[ft_resampledata](/reference/ft_resampledata)**
-- Change data to single-precision (after preprocessing by using **[ft_struct2single](/reference/ft_struct2single)** or by using "cfg.precision = 'single'" in certain functions)
+- Change data to single-precision (after preprocessing by using **[ft_struct2single](/reference/ft_struct2single)** or by using `cfg.precision = 'single'` in certain functions)
 - Check if you really have to “cfg.keeptrials = 'yes'” in **[ft_freqanalysis](/reference/ft_freqanalysis)**.
 - If you are working on a single subject, make sure other subjects are no longer in memory. This might seem trivial, but many people assign unique variables to subjects and forget to clear them.
 - Perhaps most importantly – once in a while let someone else go through your scripts to see if they can be optimized.
 - Within a script or function make sure you clear large variables that you don't need anymore using the clear statement. Note that MATLAB's memory use might not be intuitive. For instance, reloading a large dataset into the same variable may result in MATLAB allocating twice the memory you actually need.
-- The cfg field in your fieldtrip files stores the history of the processing steps performed on the data. This field can get quite large after many such steps and after appending several data files, because each cfg is stored in a cell array within the cfg.previous field. You can look at the cfg using **[ft_analysispipeline](/reference/ft_analysispipeline)**. Simply emptying this field (e.g. by doing freq.cfg = []) will free up space. Remember to keep a copy of the cfg field on disk to keep track of your analysis pipeline. 
+- The `cfg` field in your FieldTrip data structures stores the history of the processing steps performed on the data. This field can get quite large after many such steps and specifically after appending several data structures, because each `cfg` is stored in a cell array within the `cfg.previous` field. You can look at the cfg using **[ft_analysispipeline](/reference/ft_analysispipeline)**. Simply emptying this field (e.g. by doing `freq.cfg = []`) will free up space. Remember to keep a copy of the cfg field on disk if you want to keep track of your analysis pipeline. 
 
 {% include markup/warning %}
 If you have any more suggestions please add them here.
@@ -40,7 +40,7 @@ Do make sure you save the important parameters (e.g. rejected trials) so you can
 
 ## Load only as much data as you need
 
-Only import into MATLAB as much of a large data set as you need for the problem you are trying to solve. Many users are tempted to try and load the entire file first, and then process it with MATLAB. This is not always necessary. Use the _whos_ function with the _-file_ option to preview the file. This command displays each array in the MAT-file that you specify and the number of bytes in the array.
+Only import into MATLAB as much of a large data set as you need for the problem you are trying to solve. Many users are tempted to try and load the entire file first, and then process it with MATLAB. This is not always necessary. Use the `whos` function with the `-file` option to preview the file. This command displays each array in the MAT-file that you specify and the number of bytes in the array.
 
     whos -file session1.mat
     Name      Size            Bytes  Class     Attributes
@@ -55,11 +55,14 @@ seq = load('session1.mat','Seq').
 
 ## Avoid creating temporary arrays
 
-Avoid creating large temporary variables, and also make it a practice to clear those temporary variables you do use when they are no longer needed. For example, when you create a large array of zeros, instead of saving to a temporary variable A, and then converting A to a singl
-A = zeros(1e6,1);
-As = single(A);
+Avoid creating large temporary variables, and also make it a practice to clear those temporary variables you do use when they are no longer needed. For example, when you create a large array of zeros, instead of saving to a temporary variable A, and then converting A to a single
+
+    A = zeros(1e6,1);
+    As = single(A);
+
 use just the one command to do both operation
-A = zeros(1e6,1,'single');
+
+    A = zeros(1e6,1,'single');
 
 Using the repmat function, array preallocation and for loops are other ways to work on nondouble data without requiring temporary storage in memory.
 
@@ -76,7 +79,7 @@ One way to use less memory in this situation is to use nested functions. A neste
     setrowval(400, 0);
     disp('The new value of A(399:401,1:10) is')
     A(399:401,1:10)
-    end
+    end % function
 
 ## Using Appropriate Data Storage
 
@@ -87,11 +90,12 @@ MATLAB provides you with different sizes of data classes, such as double and uin
 In the course of a MATLAB session, memory can become fragmented due to dynamic memory allocation and deallocation. For and while loops that incrementally increase the size of a data structure each time through the loop can add to this fragmentation as they have to repeatedly find and allocate larger blocks of memory to store the data. When memory is fragmented, there may be plenty of free space, but not enough contiguous memory to store a new large variable.
 To make more efficient use of your memory, preallocate a block of memory large enough to hold the matrix at its final size before entering the loop. When you preallocate memory for an array, MATLAB reserves sufficient contiguous space for the entire full-size array at the beginning of the computation. Once you have this space, you can add elements to the array without having to continually allocate new space for it in memory.
 
-The following code creates a scalar variable x, and then gradually increases the size of x in a for loop instead of preallocating the required amount of memory at the star.
-x = 0;
-for k = 2:1000
-x(k) = x(k-1) + 5;
-end
+The following code creates a scalar variable x, and then gradually increases the size of x in a for loop instead of preallocating the required amount of memory at the start.
+
+    x = 0;
+    for k = 2:1000
+      x(k) = x(k-1) + 5;
+    end
 
 Change the first line to preallocate a 1-by-1000 block of memory for x initialized to zero. This time there is no need to repeatedly reallocate memory and move data as more values are assigned to x in the loop.
 
@@ -103,10 +107,11 @@ Change the first line to preallocate a 1-by-1000 block of memory for x initializ
 ## Clear old variables from memory when no longer needed
 
 When you are working with a very large data set repeatedly or interactively, clear the old variable first to make space for the new variable. Otherwise, MATLAB requires temporary storage of equal size before overriding the variable. For example,
-a = rand(100e6,1) % 800 MB array
-a = rand(100e6,1) % New 800 MB array
-??? Error using ==> rand
-Out of memory. Type HELP MEMORY for your options.
+
+    a = rand(100e6,1) % 800 MB array
+    a = rand(100e6,1) % New 800 MB array
+    ??? Error using ==> rand
+    Out of memory. Type HELP MEMORY for your options.
 
     clear a
     a = rand(100e6,1)              % New 800 MB array

--- a/tutorial/memory.md
+++ b/tutorial/memory.md
@@ -22,6 +22,7 @@ Neurophysiological data can become quite large with the result that disk space, 
 - If you are working on a single subject, make sure other subjects are no longer in memory. This might seem trivial, but many people assign unique variables to subjects and forget to clear them.
 - Perhaps most importantly – once in a while let someone else go through your scripts to see if they can be optimized.
 - Within a script or function make sure you clear large variables that you don't need anymore using the clear statement. Note that MATLAB's memory use might not be intuitive. For instance, reloading a large dataset into the same variable may result in MATLAB allocating twice the memory you actually need.
+- The cfg field in your fieldtrip files stores the history of the processing steps performed on the data. This field can get quite large after many such steps and after appending several data files, because each cfg is stored in a cell array within the cfg.previous field. You can look at the cfg using **[ft_analysispipeline](/reference/ft_analysispipeline)**. Simply emptying this field (e.g. by doing freq.cfg = []) will free up space. Remember to keep a copy of the cfg field on disk to keep track of your analysis pipeline. 
 
 {% include markup/warning %}
 If you have any more suggestions please add them here.


### PR DESCRIPTION
I've noticed a couple times that freq.cfg can get extremely big compared to the actual data in a freq struct. E.g. a struct array of 16 freq's was 162 MB, but after doing 
[freq.cfg] = deal([]); 
it was only 29 MB! ft_analysispipeline showed me a large number of cfg's for each run. I guess the reason is that ft_appenddata etc keeps the cfg of each single inputfiles...