### PR TITLE
Create news item for website and twitter

### DIFF
--- a/_posts/2020-08-20-release.md
+++ b/_posts/2020-08-20-release.md
@@ -1,0 +1,15 @@
+---
+title: 20 August 2020 - FieldTrip version 20200820 has been released
+categories: [news, release]
+tweeted: false
+---
+
+### 20 August, 2020
+
+FieldTrip version [20200820](http://github.com/fieldtrip/fieldtrip/releases/tag/20200820) has been released.
+See [GitHub](https://github.com/fieldtrip/fieldtrip/compare/20200821...20200820) for the detailled list of updates.
+
+#### Commits
+
+- [4158859](http://github.com/fieldtrip/fieldtrip/commit/4158859) improvements to Homer2 .nirs format
+- [ef5a31a](http://github.com/fieldtrip/fieldtrip/commit/ef5a31a) added (very) initial support for NIRx, see #1528

--- a/_posts/2020-08-26-release.md
+++ b/_posts/2020-08-26-release.md
@@ -1,0 +1,14 @@
+---
+title: 26 August 2020 - FieldTrip version 20200826 has been released
+categories: [news, release]
+tweeted: false
+---
+
+### 26 August, 2020
+
+FieldTrip version [20200826](http://github.com/fieldtrip/fieldtrip/releases/tag/20200826) has been released.
+See [GitHub](https://github.com/fieldtrip/fieldtrip/compare/20200821...20200826) for the detailled list of updates.
+
+#### Commits
+
+- [1181d6d](http://github.com/fieldtrip/fieldtrip/commit/1181d6d) prevent some warnings or obscure errors when running FT_QUALITYCHECK

--- a/_posts/2020-08-28-release.md
+++ b/_posts/2020-08-28-release.md
@@ -1,0 +1,21 @@
+---
+title: 28 August 2020 - FieldTrip version 20200828 has been released
+categories: [news, release]
+tweeted: false
+---
+
+### 28 August, 2020
+
+FieldTrip version [20200828](http://github.com/fieldtrip/fieldtrip/releases/tag/20200828) has been released.
+See [GitHub](https://github.com/fieldtrip/fieldtrip/compare/20200826...20200828) for the detailled list of updates.
+
+#### Commits
+
+- [89f0d49](http://github.com/fieldtrip/fieldtrip/commit/89f0d49) Merge pull request #1530 from MPIB/fix_qsub_check_torque_job
+- [444a54c](http://github.com/fieldtrip/fieldtrip/commit/444a54c) Merge pull request #1531 from MPIB/fix_qsub_slurm_support
+- [0d22957](http://github.com/fieldtrip/fieldtrip/commit/0d22957) FIX: qsub: fix checking for finished torque jobs
+- [ec3976f](http://github.com/fieldtrip/fieldtrip/commit/ec3976f) fixed cfg.dip problem for custom signal properties (#1529)
+- [daf2265](http://github.com/fieldtrip/fieldtrip/commit/daf2265) ENH: add some spaces for submitopts
+- [99b1eb6](http://github.com/fieldtrip/fieldtrip/commit/99b1eb6) ENH: qsub: use timreq and memreq for slurm
+- [760664b](http://github.com/fieldtrip/fieldtrip/commit/760664b) FIX: qsub: fix check for slurm job completion
+- [6335427](http://github.com/fieldtrip/fieldtrip/commit/6335427) FIX: qsub: revert switch to srun for slurm systems

--- a/_posts/2020-08-31-release.md
+++ b/_posts/2020-08-31-release.md
@@ -1,0 +1,40 @@
+---
+title: 31 August 2020 - FieldTrip version 20200831 has been released
+categories: [news, release]
+tweeted: false
+---
+
+### 31 August, 2020
+
+FieldTrip version [20200831](http://github.com/fieldtrip/fieldtrip/releases/tag/20200831) has been released.
+See [GitHub](https://github.com/fieldtrip/fieldtrip/compare/20200828...20200831) for the detailled list of updates.
+
+#### Commits
+
+- [5b82f4b](http://github.com/fieldtrip/fieldtrip/commit/5b82f4b) FIX - updated read_trigger to deal with regression error due to flank detection and due to denoising, see #1535
+- [828f4cf](http://github.com/fieldtrip/fieldtrip/commit/828f4cf) Merge pull request #1534 from robertoostenveld/nirs-reading
+- [5b044c3](http://github.com/fieldtrip/fieldtrip/commit/5b044c3) Merge pull request #1533 from robertoostenveld/nirs-plotting
+- [21d1045](http://github.com/fieldtrip/fieldtrip/commit/21d1045) renamed cfg.newfigure into cfg.figure
+- [28f2fd2](http://github.com/fieldtrip/fieldtrip/commit/28f2fd2) do not assign defaults for headerformat and dataformat, they do not apply in case a data structure is specified as input argument
+- [05a7f88](http://github.com/fieldtrip/fieldtrip/commit/05a7f88) give error if there are no channels
+- [df0f71b](http://github.com/fieldtrip/fieldtrip/commit/df0f71b) updated help and/or comments
+- [87db43b](http://github.com/fieldtrip/fieldtrip/commit/87db43b) cleaned up whitespace, no functional changes
+- [f4cea0d](http://github.com/fieldtrip/fieldtrip/commit/f4cea0d) improve denoising and added fixhomer option
+- [5753754](http://github.com/fieldtrip/fieldtrip/commit/5753754) represent the homer "s" channels just like the aux and data channels, also for triger detection
+- [4cf67c2](http://github.com/fieldtrip/fieldtrip/commit/4cf67c2) added trigger duration based on time between up and down flank
+- [0fcf0c4](http://github.com/fieldtrip/fieldtrip/commit/0fcf0c4) try to parse the AUX channel for events if there are no events in nirs.s for homer
+- [a5bc749](http://github.com/fieldtrip/fieldtrip/commit/a5bc749) concatenate the AUX channel with the NIRS channels for homer format
+- [aa7a36f](http://github.com/fieldtrip/fieldtrip/commit/aa7a36f) concatenate the AUX channel at the end of the data (for Homer NIRS files)
+- [88c21d4](http://github.com/fieldtrip/fieldtrip/commit/88c21d4) ensure that hdr.opto is according to the latest standards
+- [8312887](http://github.com/fieldtrip/fieldtrip/commit/8312887) renamed opto.transmits into opto.tra and removed opto.laserstrength
+- [f955164](http://github.com/fieldtrip/fieldtrip/commit/f955164) opto.transmits serves the same purpose as opto.tra
+- [f0329f6](http://github.com/fieldtrip/fieldtrip/commit/f0329f6) corrected documentation for opto.tra and opto.transmits, this was inconsistent with the Artinis implementation
+- [9177c14](http://github.com/fieldtrip/fieldtrip/commit/9177c14) opto.transmits serves the same purpose as opto.tra
+- [04bbcd7](http://github.com/fieldtrip/fieldtrip/commit/04bbcd7) synchronize ft_fetch_sens over private directories
+- [e21b30a](http://github.com/fieldtrip/fieldtrip/commit/e21b30a) use ft_read_header when reading ffrom one of the NIRS file formats, since these all have optode information in the header
+- [0f6f9ad](http://github.com/fieldtrip/fieldtrip/commit/0f6f9ad) added support for reading optode and fiducial positions from brainsight_txt
+- [15a8520](http://github.com/fieldtrip/fieldtrip/commit/15a8520) imporove construction of NIRS optode layout for plotting
+- [2b29292](http://github.com/fieldtrip/fieldtrip/commit/2b29292) pass the skipcomnt and skipscale option from the high level plotting functions to ft_prepare_layout
+- [6a0e48a](http://github.com/fieldtrip/fieldtrip/commit/6a0e48a) fixed bug when plotting individual optodes, where the number of optodes is different than the number of channels
+- [813b7f1](http://github.com/fieldtrip/fieldtrip/commit/813b7f1) added support for cfg.newfigure=yes/no/new/clf/gcf/handle
+- [fd99746](http://github.com/fieldtrip/fieldtrip/commit/fd99746) added support for cfg.newfigure using open_figure() helper function, the default is to open a new one


### PR DESCRIPTION
@Spaak and @elshafeh, imagine that you would get a pull request like this, but then only with a single news item pertaining to a single release. This one contains 4 items for 4 releases to have a better reflection of the variance of the releases. 

How would you change the text to appear on the website? 

How would you fit it in the 280 character limit and convert it in a tweet?

Rather than the `tweeted: true/false` flag that these items now have in their (invisible) heading, it would also be possible to add a heading such as `tweet: here goes the text ... see also LINK_TO_HOMEPAGE` which would allow for detailled curation of the tweet as well.   
