### PR TITLE
Cookiefix and news styling

### DIFF
--- a/_includes/cookie-banner
+++ b/_includes/cookie-banner
@@ -8,7 +8,9 @@
 </style>
 
 <div id="cookie-notice"><span>We would like to use third party cookies and scripts to improve the functionality of this website.</span>
-<a id="cookie-notice-accept" class="btn btn-primary btn-sm">Approve</a>
+<span id="CookieModal" class="in">
+<a id="cookie-notice-accept" class="btn btn-primary btn-sm" data-dismiss="true">Approve</a>
+</span>
 <a id="cookie-notice-reject" class="btn btn-primary btn-sm">Reject</a>
 <a href="/privacy" class="btn btn-primary btn-sm">More info</a></div>
 
@@ -16,9 +18,13 @@
 
   if(readCookie('allow-external-cookies')=='true') {
     // third party cookies and scripts are allowed by the user
+    let elem = document.getElementById('cookie-notice');
+    elem.parentNode.removeChild(elem);
   }
   else if(readCookie('allow-external-cookies')=='false') {
-    // third party cookies and scripts are now allowed by the user
+    // third party cookies and scripts are not allowed by the user
+    let elem = document.getElementById('cookie-notice');
+    elem.parentNode.removeChild(elem);
   }
   else {
     // show the cookie banner and ask for permission for the next 31 days

--- a/_includes/cookie-banner
+++ b/_includes/cookie-banner
@@ -29,17 +29,17 @@
   else {
     // show the cookie banner and ask for permission for the next 31 days
     document.getElementById('cookie-notice').style.display = 'block';
-  }
 
-  document.getElementById('cookie-notice-accept').addEventListener("click",function() {
-    createCookie('allow-external-cookies','true',31);
-    document.getElementById('cookie-notice').style.display = 'none';
-    location.reload();
-  });
-  document.getElementById('cookie-notice-reject').addEventListener("click",function() {
-    createCookie('allow-external-cookies','false',31);
-    document.getElementById('cookie-notice').style.display = 'none';
-    location.reload();
-  });
+    document.getElementById('cookie-notice-accept').addEventListener("click",function() {
+      createCookie('allow-external-cookies','true',31);
+      document.getElementById('cookie-notice').style.display = 'none';
+      location.reload();
+    });
+    document.getElementById('cookie-notice-reject').addEventListener("click",function() {
+      createCookie('allow-external-cookies','false',31);
+      document.getElementById('cookie-notice').style.display = 'none';
+      location.reload();
+    });
+  }
 
 </script>

--- a/assets/css/custom/_customstyles.scss
+++ b/assets/css/custom/_customstyles.scss
@@ -122,3 +122,17 @@ table {
       margin-top: 0; }
     table tr th :last-child, table tr td :last-child {
       margin-bottom: 0; }
+
+/* -------------------------------------------------- */
+/* Homepage styles for releases and news items */
+
+#sec-latest-release {
+  border-top: 1px solid #bbb;
+  border-bottom: 1px solid #bbb;
+  padding-bottom: 0.5em;
+}
+#sec-news-and-announcements .post-excerpt {
+  border-top: 1px dashed #ccc;
+  border-bottom: 1px dashed #ccc;
+  padding-top: 1em;
+}

--- a/index.md
+++ b/index.md
@@ -14,6 +14,8 @@ Robert Oostenveld, Pascal Fries, Eric Maris, and Jan-Mathijs Schoffelen. **[Fiel
 
 To get started, head over to the [getting started](/getting_started) documentation and the [tutorials](/tutorial).
 
+<section id="latest-release" markdown="1">
+
 ## Latest release
 
 _The latest code developments can be tracked in detail on [GitHub](/development/git)._
@@ -24,11 +26,17 @@ _The latest code developments can be tracked in detail on [GitHub](/development/
 
 {% if counter == 0 %}
 {% assign counter = counter | plus: 1 %}
+<div class="post-excerpt" markdown="1">
 {{ post.excerpt }}
+</div>
 {% endif %}
 
 {% endif %}
 {% endfor %}
+
+</section>
+
+<section id="news-and-announcements" markdown="1">
 
 ## News and announcements
 
@@ -40,8 +48,12 @@ _You can also follow us on [Twitter](http://twitter.com/fieldtriptoolbx)._
 
 {% if counter < 7 %}
 {% assign counter = counter | plus: 1 %}
+<div class="post-excerpt" markdown="1">
 {{ post.excerpt }}
+</div>
 {% endif %}
 
 {% endif %}
 {% endfor %}
+
+</section>

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ Robert Oostenveld, Pascal Fries, Eric Maris, and Jan-Mathijs Schoffelen. **[Fiel
 
 To get started, head over to the [getting started](/getting_started) documentation and the [tutorials](/tutorial).
 
-<section id="latest-release" markdown="1">
+<section id="sec-latest-release" markdown="1">
 
 ## Latest release
 
@@ -36,7 +36,7 @@ _The latest code developments can be tracked in detail on [GitHub](/development/
 
 </section>
 
-<section id="news-and-announcements" markdown="1">
+<section id="sec-news-and-announcements" markdown="1">
 
 ## News and announcements
 


### PR DESCRIPTION
This PR does 2 things:

- It improves compatibility of our cookie popup with certain browser extensions that people can use to manage their cookie permissions. The PR has no effect for people who do not use such extensions.
- It adds some very low-key styling to the release and news sections of the homepage, in order to make them a bit easier to parse visually.