### PR TITLE
Update human_ecog.md

### DIFF
--- a/tutorial/human_ecog.md
+++ b/tutorial/human_ecog.md
@@ -262,7 +262,10 @@ CRITICAL STEP Accuracy of the spatial normalization step is important for correc
 
     [ftver, ftpath] = ft_version;
     load([ftpath filesep 'template/anatomy/surface_pial_left.mat']);
-    template_lh = mesh;
+    
+    % rename the variable that we read from the file, as not to confuse it with the MATLAB mesh plotting function   
+    template_lh = mesh; clear mesh;
+    
     ft_plot_mesh(template_lh);
     ft_plot_sens(elec_mni_frv);
     view([-90 20]);

--- a/tutorial/human_ecog.md
+++ b/tutorial/human_ecog.md
@@ -262,7 +262,8 @@ CRITICAL STEP Accuracy of the spatial normalization step is important for correc
 
     [ftver, ftpath] = ft_version;
     load([ftpath filesep 'template/anatomy/surface_pial_left.mat']);
-    ft_plot_mesh(mesh);
+    template_lh = mesh;
+    ft_plot_mesh(template_lh);
     ft_plot_sens(elec_mni_frv);
     view([-90 20]);
     material dull;


### PR DESCRIPTION
Matlab can get confused as to whether a label refers to a function or variable/struct. Renaming the mesh struct (from 'mesh' into 'template_lh') after loading it in is meant to avoid that issue.