### PR TITLE
convert multiple authors in str to array of strs

### DIFF
--- a/example/bids_eyetracker.md
+++ b/example/bids_eyetracker.md
@@ -183,7 +183,7 @@ cfg.dataset_description.Name                = 'Visual Stability: predictive rema
 cfg.dataset_description.BIDSVersion         = 'unofficial extension';
 
 % optional for dataset_description.json
-cfg.dataset_description.Authors             = 'Tao He, Matthias Fritsche, Floris de Lange';
+cfg.dataset_description.Authors             = {'Tao He', 'Matthias Fritsche', 'Floris de Lange'};
 cfg.dataset_description.DatasetDOI          = 'http://hdl.handle.net/11633/di.dccn.DSC_3018034.01_694';
 cfg.dataset_description.License             = 'RU-DI-HD-1.0';
 cfg.dataset_description.Acknowledgements    = 'n/a';

--- a/example/bids_meg.md
+++ b/example/bids_meg.md
@@ -107,7 +107,7 @@ for subindx=1:numel(subj)
     
     % optional for dataset_description.json
     cfg.dataset_description.License             = 'RU-DI-HD-1.0';
-    cfg.dataset_description.Authors             = 'Te Woerd ES, Oostenveld R, de Lange FP, Praamstra P';
+    cfg.dataset_description.Authors             = {'Te Woerd ES', 'Oostenveld R', 'de Lange FP, Praamstra P'};
     cfg.dataset_description.ReferencesAndLinks  = {'https://doi.org/10.1152/jn.00547.2016'};
     cfg.dataset_description.EthicsApprovals     = 'DCCN 3018009.04';
     

--- a/example/bids_nirs.md
+++ b/example/bids_nirs.md
@@ -127,7 +127,7 @@ The complete original dataset is available from Mendeley, a subset of the raw da
 
       % the following settings relate to the dataset_description.json
       cfg.dataset_description.Name                = 'Defenderfer 2019; fNIRS data files for event-related vocoding/background noise study';
-      cfg.dataset_description.Authors             = 'Defenderfer, Jessica; Buss, Aaron ';
+      cfg.dataset_description.Authors             = {'Defenderfer, Jessica', 'Buss, Aaron'};
       cfg.dataset_description.DatasetDOI          = 'http://dx.doi.org/10.17632/4cjgvyg5p2.1';
       cfg.dataset_description.License             = 'CC BY 4.0';
       cfg.dataset_description.ReferencesAndLinks  = {'https://www.fieldtriptoolbox.org/example/nirs_speech/'}; % this can be a list


### PR DESCRIPTION
Some of the BIDS examples specify the `cfg.dataset_description.Authors` for multiple authors as one string rather than an array of strings.

This PR fixes that issue.