### PR TITLE
Added FAQ: ''why should I set cfg.continuous = 'yes' when preprocessing CTF trial-based data?''

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -17,6 +17,7 @@ See also the [tutorials](/tutorial) and [example scripts](/example).
 - [How can I inspect the electrode impedances of my data?](/faq/how_can_i_inspect_the_electrode_impedances_of_my_data)
 - [Should I rereference my EEG data prior to, or after ICA?](/faq/should_I_rereference_prior_to_or_after_ica_for_artifact_removal)
 - [I used to work with trl-matrices that have more than 3 columns. Why is this not supported anymore?](/faq/i_used_to_work_with_trl-matrices_that_have_more_than_3_columns._why_is_this_not_supported_anymore)
+- [Why should I set cfg.continuous = 'yes' when preprocessing CTF trial-based data?](/faq/continuous)
 
 ### Specific data formats
 

--- a/faq/continuous.md
+++ b/faq/continuous.md
@@ -1,0 +1,18 @@
+---
+title: Why should I set cfg.continuous = 'yes' when preprocessing CTF trial-based data?
+tags: [faq, ctf, preprocessing, continuous]
+---
+
+# Why should I set cfg.continuous = 'yes' when preprocessing CTF trial-based data?
+
+The CTF acquisition software by default writes data to disk in blocks. The length of these blocks can be configured, and at the DCCN this is set to 10 seconds. So the continuous recording is actually pseudo-continuous and consists of blocks of 10 seconds, where block N is followed smoothly without gaps by block N+1. However, the CTF acquisition software can also be configured to only write a block of data to disk upon a trigger. This results in "epoched" data, where only the data corresponding to the trial is written to disk and the data in the inter trial intervals is not. In this case there is a gap between block N and block N+1. If you were to read the epoched data as if it were continuously, you won't see the gaps as such along the time axis, but you will see jumps in the data as the signal may have drifted from block N to block N+1. 
+
+FieldTrip does not distinguish between the CTF files that are written as blocks in continuous mode, without gaps, and CTF files that are written as epochs with gaps between the blocks. The low-level reading functions by default will give an error when you try to read data that extends over a boundary between two blocks, but the `cfg.continuous` option in **[ft_preprocessing](/reference/ft_preprocessing)** allows you to override that.
+
+The "Subject01.ds" CTF dataset that is used in some tutorials is epoched and has gaps between the trials. If you were to read that as continuous, you would see discontinuities in the MEG channels. If you were to apply the automatic artifact detection functions on that as continuous data, many trials would be detected as an artifact as they start/end with a discontinuous jump in some of the channels. Hence when reading that data the `cfg.continuous` option should be set to `"no"` (which is the default).
+
+Many other CTF datasets are recorded as pseudocontinuous without gaps between the blocks and for those you do want to set the `cfg.continuous` option to `"yes"`. 
+
+To check whether your data is epoched or pseudocontinuous, please have a look at the `SCLK01` channel.
+
+Note that besides **[ft_preprocessing](/reference/ft_preprocessing)**, other functions that read data from disk also have the `cfg.continuous` option, such as  **[ft_databrowser](/reference/ft_databrowser)** and the automatic artifact detection functions.

--- a/faq/continuous.md
+++ b/faq/continuous.md
@@ -1,6 +1,7 @@
 ---
 title: Why should I set cfg.continuous = 'yes' when preprocessing CTF trial-based data?
 tags: [faq, ctf, preprocessing, continuous]
+authors: [Konstantinos Tsilimparis, Robert Oostenveld]
 ---
 
 # Why should I set cfg.continuous = 'yes' when preprocessing CTF trial-based data?

--- a/faq/why_should_I_set_cfg.continuous_equal_to_yes_when_preprocessing_ctf_trial_based_data.md
+++ b/faq/why_should_I_set_cfg.continuous_equal_to_yes_when_preprocessing_ctf_trial_based_data.md
@@ -1,0 +1,9 @@
+---
+title: Why should I set cfg.continuous = 'yes' when preprocessing CTF trial-based data?
+tags: [faq, ctf, preprocessing]
+---
+
+# Why should I set cfg.continuous = 'yes' when preprocessing CTF trial-based data?
+
+When storing a continuous CTF recording in disk, the CTF acquisition software automatically adds a trigger every 10 seconds alongside your custom triggers. To virtually stitch together these 10-second segments into one continuous recording , you must set cfg.continuous = 'yes' in **[ft_preprocessing](/reference/ft_preprocessing)**. That way you can perform trial-based MEG analysis using your custom triggers. This is also done in the [Preprocessing - Segmenting and reading trial-based EEG and MEG data](tutorial/preprocessing) tutorial.
+

--- a/faq/why_should_I_set_cfg.continuous_equal_to_yes_when_preprocessing_ctf_trial_based_data.md
+++ b/faq/why_should_I_set_cfg.continuous_equal_to_yes_when_preprocessing_ctf_trial_based_data.md
@@ -1,9 +1,0 @@
----
-title: Why should I set cfg.continuous = 'yes' when preprocessing CTF trial-based data?
-tags: [faq, ctf, preprocessing]
----
-
-# Why should I set cfg.continuous = 'yes' when preprocessing CTF trial-based data?
-
-When storing a continuous CTF recording in disk, the CTF acquisition software automatically adds a trigger every 10 seconds alongside your custom triggers. To virtually stitch together these 10-second segments into one continuous recording , you must set cfg.continuous = 'yes' in **[ft_preprocessing](/reference/ft_preprocessing)**. That way you can perform trial-based MEG analysis using your custom triggers. This is also done in the [Preprocessing - Segmenting and reading trial-based EEG and MEG data](tutorial/preprocessing) tutorial.
-

--- a/tag/reproducescript.md
+++ b/tag/reproducescript.md
@@ -1,4 +1,0 @@
----
-layout: tag
-tag: reproducescript
----

--- a/tag/script.md
+++ b/tag/script.md
@@ -1,4 +1,0 @@
----
-layout: tag
-tag: script
----

--- a/tutorial/preprocessing.md
+++ b/tutorial/preprocessing.md
@@ -49,7 +49,7 @@ This results in a cfg.trl that contains the trial definitions of all conditions 
 The output of **[ft_definetrial](/reference/ft_definetrial)** can be used for **[ft_preprocessing](/reference/ft_preprocessing)**.
 
     cfg.channel    = {'MEG' 'EOG'};
-    cfg.continuous = 'yes';
+    cfg.continuous = 'yes'; % see https://www.fieldtriptoolbox.org/faq/continuous/
     data_all = ft_preprocessing(cfg);
 
     Save the data to disk


### PR DESCRIPTION
As discussed with @schoffelen, this question was raised by @contsili and other external FieldTrip users.

Perhaps a hyperlink from the [preprocessing tutorial](https://www.fieldtriptoolbox.org/tutorial/preprocessing/) to the FAQ could clarify why cfg.continuous is set to 'yes' in the tutorial. Many users copy the tutorial to their own analysis and use cfg.continuous='yes' for EEG or MEG data (other than CTF) without understanding the reasoning behind it.

Small note: I could not clone two files. I believe this is a windows problem (see commit be45c95). 