### PR TITLE
add parallel/serial tigger tutorial and example PsyPy scripts

### DIFF
--- a/workshop/nigeria2025/EEGexperiment_template.py
+++ b/workshop/nigeria2025/EEGexperiment_template.py
@@ -1,0 +1,95 @@
+################################################################################
+# Experiment template
+# This is a basic template for a PsychoPy experiment. 
+################################################################################
+# 1. IMPORT
+
+from psychopy import ... # Import necessary modules from PsychoPy, typically including visual, event, core, and data
+
+# Other imports may include: random, serial, pylsl, parallel depending on your setup and requirements. See examples below.
+
+################################################################################
+# 2. EXPERIMENT PARAMETERS
+# Define experiment parameters such as window size, colors, etc.
+
+n_trials = ...  # Number of trials
+
+
+# Create a PsychoPy window for visual stimuli.
+# see options at https://www.psychopy.org/api/visual/window.html
+win = visual.Window() 
+
+################################################################################
+# 3. DEFINE STIMULI
+# Create stimuli for the experiment.
+stimulus = visual.TextStim(win, text='Hello, World!', color='white', height=0.1)
+
+################################################################################
+# 4. SETUP EEG TRIGGERS
+# If you are using EEG triggers, set up the connection here.
+# For example, using a serial port or parallel port for sending triggers.
+# Below are three example methods to set up triggers. Only use the one that matches your setup.
+
+# option A: parallel port
+try:
+    port = parallel.setPortAddress(0x378)  # address for parallel port on many machines (CHECK!!)
+    port_type = 'parallel'
+
+# Option C: parallel port
+try:
+    port = serial.Serial("COM9", 115200)  # Change COM port to match your setup
+    port_type = 'serial'
+
+# Option C: LSL
+name = "My Experiment"
+strm_type = "Markers"
+chans = 1
+srate = 0
+fmt = 'string'
+
+info = pylsl.StreamInfo(
+    name=name,
+    type=strm_type,
+    channel_count=chans,
+    nominal_srate=srate,
+    channel_format=fmt,
+    )
+    
+outlet = pylsl.StreamOutlet(info)
+
+# Make a trigger function based on the port type
+# Option A: parallel port
+def trigger(code=1):
+    port.setData(code)
+    print('trigger sent {}'.format(code)) # Print code for debugging
+# Option B: serial port
+def trigger(code=1):
+    port.write(code.to_bytes(1, 'big'))
+    print('trigger sent {}'.format(code)) # Print code for debugging
+# Option C: LSL
+def trigger(code=1):
+    outlet.push_sample(str(code))
+    print('trigger sent {}'.format(code)) # Print code for debugging
+
+################################################################################
+# 4. DEFINE TRIAL LIST
+# For multiple experimental conditions, it is a good idea to define a trial list and randomise it in advance.
+...
+
+################################################################################
+# 5. RUN EXPERIMENT
+
+# loop through the number of trials and present stimuli
+for trial in range(n_trials):
+    # Draw the stimulus
+    stimulus.draw()
+    
+    # Flip the window to show the stimulus
+    win.flip()
+    
+    # Wait for a key press to proceed to the next trial
+    event.waitKeys()
+
+# Close the window and end the experiment
+win.close()
+core.quit()

--- a/workshop/nigeria2025/oddball_response_eeg.py
+++ b/workshop/nigeria2025/oddball_response_eeg.py
@@ -1,0 +1,152 @@
+################################################################################
+# Oddball EEG Experiment Tutorial
+################################################################################
+# This script demonstrates a simple "oddball" paradigm for EEG experiments.
+# The oddball paradigm is used to study how the brain responds to rare ("deviant")
+# stimuli among frequent ("standard") stimuli, as in Näätänen et al. (1978).
+#
+# The experiment presents a sequence of tones:
+#   - Most are "standard" (1000 Hz, blue text)
+#   - Some are "deviant" (1140 Hz, red text)
+# Participants are instructed to press SPACE when they hear a deviant tone.
+# EEG triggers are sent for each stimulus and response.
+#
+# Key Sections:
+# 1. Imports and Parameters
+# 2. Trial List Generation
+# 3. EEG Trigger Setup
+# 4. Main Experiment Loop
+#
+# Walk through the code and see comments for explanations!
+# Try modifying parameters or the trial structure to see how the experiment changes!
+
+################################################################################
+
+# 1. IMPORTS AND PARAMETERS
+# Import necessary libraries for stimulus presentation, timing, sound, and EEG triggers.
+from psychopy import visual, core, sound, event, parallel
+import random
+import serial
+
+# Set the number of trials and the probability of a deviant tone.
+n_trials        = 1000  # Total number of trials
+deviant_prob    = 0.2  # Probability of a deviant tone
+
+# Create a PsychoPy window for visual stimuli.
+win = visual.Window([800, 600])
+
+################################################################################
+# 2. TRIAL LIST GENERATION
+################################################################################
+
+# This function creates a list of trials, with 1 = standard, 0 = deviant.
+# Deviants are spaced out so the first three are always standard.
+def make_triallist(length, ratio):
+    num_ones = int(length*ratio)
+    num_zeros = length-num_ones
+    array = [1]*num_ones
+
+    pos = 2  # Ensure the first 3 stimuli are standard
+    for ii in range(num_zeros):
+        pos = pos + random.randint(2, 8)
+        if pos < len(array):
+            array.insert(pos, 0)
+    
+    print(array)  # For debugging: shows the trial sequence
+    return array
+
+################################################################################
+# 3. EEG TRIGGER SETUP
+################################################################################
+
+# The script tries to connect to a serial port for EEG triggers.
+# If unavailable, it tries the parallel port. If neither, triggers are not sent.
+try:
+    port = serial.Serial("COM9", 115200)  # Change COM port to match your setup
+    port_type = 'serial'
+except NotImplementedError:
+    port = parallel.setPortAddress(0x378) # address for parallel port on many machines (CHECK!!)
+    port_type = 'parallel'
+except:
+    port_type = 'Not set'
+
+print('port type: {}'.format(port_type))
+
+# Define the trigger function based on available port type.
+if port_type == 'parallel':
+    def trigger(code=1):
+        port.setData(code)
+        print('trigger sent {}'.format(code))
+elif port_type == 'serial':
+    def trigger(code=1):
+        port.write(code.to_bytes(1, 'big'))
+        print('trigger sent {}'.format(code))
+else:
+    def trigger(code=1):
+        print('trigger not sent {}'.format(code))
+
+################################################################################
+# 4. MAIN EXPERIMENT LOOP
+################################################################################
+
+def run_task(n_trials, ratio):
+    
+    trl_list = make_triallist(n_trials, ratio)
+
+    # Define standard and deviant tones
+    standard_tone = sound.Sound(1000, sampleRate=44100, secs=0.031, stereo=True)
+    deviant_tone = sound.Sound(1140, octave=4, sampleRate=44100, secs=0.031, stereo=True)
+
+    # Visual feedback for each tone
+    standard_text = visual.TextStim(win, text='Standard', color='blue')
+    deviant_text = visual.TextStim(win, text='Deviant', color='red')
+    blank_text = visual.TextStim(win, text='', color='red')
+
+    # Loop through each trial
+    for tt, trl in enumerate(trl_list):
+        nextFlip = win.getFutureFlipTime()
+        if trl == 0:
+            deviant_tone.play(when=nextFlip)
+            deviant_text.draw()
+            trig = 2
+        else:
+            standard_tone.play(when=nextFlip)
+            standard_text.draw()
+            trig = 1
+
+        win.callOnFlip(trigger, trig)
+        win.flip()  # Show the visual stimulus
+
+        # Collect responses during the stimulus duration
+        response = None
+        timeout = None
+        timer = core.Clock()
+        while timer.getTime() < 0.80:
+            keys = event.getKeys(keyList=["SPACE", "space"])
+            if keys and response is None:
+                response = True
+                if trl == 0:
+                    print('correct!')
+                    trigger(4)
+                else:
+                    print('wrong!')
+                    trigger(8)
+            
+            if timer.getTime() > 0.25 and timeout is None:
+                timeout = True
+                blank_text.draw()
+                win.flip()
+
+        # Allow quitting with Esc or q
+        if event.getKeys(keyList=["escape", "q"]):
+            core.quit()
+
+    # Close the window at the end
+    win.close()
+    core.quit()
+
+################################################################################
+# 5. RUN THE EXPERIMENT
+################################################################################
+run_task(n_trials, deviant_prob)
+################################################################################

--- a/workshop/nigeria2025/oddball_response_lslTriggers.py
+++ b/workshop/nigeria2025/oddball_response_lslTriggers.py
@@ -1,0 +1,120 @@
+# A simple oddball experiment for EEG demo
+#   cf Näätänen et al 1978 (https://doi.org/10.1016/0001-6918(78)90006-9)
+from psychopy import visual, core, sound, event
+import random
+import serial
+import pylsl
+
+# Parameters
+n_trials        = 1000  # Total number of trials
+deviant_prob    = 0.2  # Probability of a deviant tone
+
+# Create a window
+win = visual.Window([800, 600])
+
+################################################################################
+# FUNCITONS
+################################################################################
+
+# MAKE TRIAL STRUCTURE
+def make_triallist(length, ratio):
+    num_ones = int(length*ratio)
+    num_zeros = length-num_ones
+    array = [1]*num_ones
+
+    pos = 2  # Ensure the first 3 stimuli are standard
+    for ii in range(num_zeros):
+        pos = pos + random.randint(2, 8)
+        if pos < len(array):
+            array.insert(pos, 0)
+    
+    print(array)
+    return array
+    
+# EEG TRIGGER WITH LSL
+name = "oddball_task"
+strm_type = "Markers"
+chans = 1
+srate = 0
+fmt = 'string'
+
+info = pylsl.StreamInfo(
+    name=name,
+    type=strm_type,
+    channel_count=chans,
+    nominal_srate=srate,
+    channel_format=fmt,
+    )
+    
+outlet = pylsl.StreamOutlet(info)
+print("Now publishing stream:", info.name(), info.type(), info.channel_count(), "channels at", info.nominal_srate(), "Hz")
+
+def trigger(code=1):
+    outlet.push_sample(str(code))
+    print("Pushed marker {}" .format(code))
+
+# RUN TASK
+def run_task(n_trials, ratio):
+    
+    trl_list = make_triallist(n_trials, ratio)
+
+    # Define the standard and deviant sounds
+    standard_tone = sound.Sound(1000, sampleRate=44100, secs=0.031, stereo=True)             # Standard tone
+    deviant_tone = sound.Sound(1140, octave=4, sampleRate=44100, secs=0.031, stereo=True)    # Deviant tone
+
+    # Define visual stimuli (here a text showing what tone is playes)
+    standard_text = visual.TextStim(win, text='Standard', color='blue')
+    deviant_text = visual.TextStim(win, text='Deviant', color='red')
+    blank_text = visual.TextStim(win, text='', color='red')
+    fixation = visual.TextStim(win, text='+', color='white')
+
+    # Trial loop
+    for tt, trl in enumerate(trl_list):
+        nextFlip = win.getFutureFlipTime()
+        # Find the tone to play and set stimuli accordingly
+        if trl == 0:
+            deviant_tone.play(when = nextFlip)
+            deviant_text.draw()
+            trig = 2
+        else:
+            standard_tone.play(when = nextFlip)
+            standard_text.draw()
+            trig = 1
+        
+        # Que the trigger and present stimuli
+        win.callOnFlip(trigger, trig)        
+        win.flip()  # Show the visual stimulus
+
+        # Collect responses during the stimulus duration
+        response = None
+        timeout = None
+        timer = core.Clock()
+        while timer.getTime() < 0.80:
+            keys = event.getKeys(keyList=["SPACE", "space"])
+            if keys and response is None:
+                response = True
+                if trl == 0:
+                    print('correct!')
+                    trigger(3)
+                else:
+                    print('wrong!')
+                    trigger(4)
+            
+            if timer.getTime() > 0.25 and timeout is None:
+                timeout = True
+                blank_text.draw()
+                win.flip()
+        
+        # Check for quit (the Esc or q key)
+        if event.getKeys(keyList=["escape","q"]):
+            core.quit()
+
+    # Close the window
+    win.close()
+    core.quit()
+
+################################################################################
+# RUN
+################################################################################
+run_task(n_trials, deviant_prob)
+

--- a/workshop/nigeria2025/stimuli.md
+++ b/workshop/nigeria2025/stimuli.md
@@ -95,6 +95,91 @@ while True:
 
 ```
 
+### Sending triggers using parallel ports
+
+Parallel ports sends values based on parallel "pins" that each represents a bit in a binary number. For example with eight pins, you can write values from 0-255. Parallel ports are generally the most reliable way of sending triggers as all information is send at the same time. 
+
+Be aware that modern PCs and laptops usually do not have parallel ports. In that case, see how to send "parallel" triggers with a serial ports below.
+
+```Python
+from psychopy import parallel
+
+# Define the port
+port = parallel.ParallelPort(0x0378)  
+
+```
+
+``0x0378`` is the default address for parallel port on many Windows machines, but can change from PC to PC. Change to match your machine. To find the adress, find the parllel port in the Windows Systems Settings.
+
+To send the triggers, place this code at the appropiate place in your experiment script:
+
+```Python
+port.setData(code)        # Send trigger code 
+port.setData(0)           # Send code 0 = reset pins
+print('trigger sent {}'.format(code)) # Print code to terminal for debugging
+```
+
+This will the signal ``code`` to the parallel port. ``Code`` should be an integer equal to the trigger value.
+
+### Sending triggers using serial ports (incl. USB)
+
+Serial ports can send different values where the information is send in series of "packages". This means that the timing and how the codes are read at the reciving end can be off if not handled correctly. Serial ports can be used to emulate parallel ports if given only length 1 and proper encoding.
+
+Define the serial port using the ``Serial`` Python package:
+
+```Python
+import serial
+
+# Define the port
+port = serial.Serial("COM4", 115200) 
+```
+In this example, the address for serial port is ``COM4``. The port address change depending on the PC and how the external defince is connected. Change the adress to match your machine.
+
+This example takes the integer `code` and transformes it to a code that can be send over serial to emulate a parallel trigger (note this only works for numbers 0-255):
+
+```python
+port.write(code.to_bytes(1, 'big'))     # Send trigger code
+print('trigger sent {}'.format(code))   # Print code to terminal for debugging
+
+```
+
+#### Find the USB serial port address
+Plug in the USB/parllel cable connected to the EEG system.
+
+##### Windows
+On most Windows machines the serial port is callel "COM" and a number, e.g., "COM3". The exact name vary from machine to machine. Open the Device Manager (from the menu). Go to the overview of devices. Find the one corresponding to the connected device. Somewhere in the name it (usually) list the COM name.
+
+If not, you can try a "brute force" test, and see if you get triggers with any adresses, starting with "COM1", "COM2", and so on.
+
+##### Mac
+On Mac, USB ports are found under "devices" and called "tty.<something>. To find the name, connect the cable, then open a terminal and type:
+
+```bash
+ls /dev/tty.*
+```
+Then find the name that match the connected device. E.g.: 
+
+````python
+port = serial.Serial('/dev/tty.usbserial-DN2Q03LO', 115200)
+````
+
+### Use win.callOnFlip() to time triggers in PsychoPy
+PsychoPy has a build-in method that is supposed to control the timing in how it executes functions to deliver stimuli related to the ``Window`` module called `callOnFlip()`. The method takes a function and the input to the function as arguments and will call the function immediately after the next ``flip()`` command. If this the next `flip()` is when the visual stimuli is drawn, the should be function will be executed when the stimuli is drawn.
+
+The first argument should be the function to call, the following args should be used exactly as you would for your normal call to the function (can use ordered arguments or keyword arguments as normal):  ``callOnFlip(function, *args, **kwargs)``
+
+E.g. If you have a function that you would normally call like this (code is the trigger value):
+
+````python
+port.write(code.to_bytes(1, 'big'))
+````
+You call it though ``callOnFlip()`` like this:
+
+```python
+win.callOnFlip(port.write, code.to_bytes(1, 'big')) 
+```
+Using this procedure should improve timing.
+
 ## MATLAB
 
 At the Donders we are using trigger boxes that are based on the Arduino Uno or Arduino Mega development boards, which we call "Bitsi" boxes. These boxes have a numner of TTL inputs and TTL outputs and are [programmed](https://github.com/robertoostenveld/arduino/tree/main/bitsi) to send the byte that they receive over the serial port to the parallel output. The parallel output is connected to the EEG or MEG system.


### PR DESCRIPTION
Updated the `Stimuli.md` tutorial page with examples for parallel and serial ports, incl. how to find the serial port address on Win and Mac.

I have also added example scripts for the auditory oddball experiment in two versions: one with parallel or serial triggers and one with LSL triggers. Also added the blank template script.